### PR TITLE
 Enqueued the script with wp_enqueued_script instead of wp_print_scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .svn/
+.idea/

--- a/includes/class-gmb-scripts.php
+++ b/includes/class-gmb-scripts.php
@@ -41,7 +41,8 @@ class Google_Maps_Builder_Scripts {
 
 		add_action( 'init', array( $this, 'register_gmap_scripts' ) );
 
-		add_action( 'wp_footer', array( $this, 'print_gmap_footer' ), 100 );
+//		add_action( 'wp_footer', array( $this, 'print_gmap_footer' ), 100 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'print_gmap_footer' ), 100 );
 
 		add_action( 'wp_head', array( $this, 'check_for_multiple_google_maps_api_calls' ) );
 
@@ -126,7 +127,7 @@ class Google_Maps_Builder_Scripts {
 
 		$google_maps_api_url = add_query_arg( $google_maps_api_url_args, 'https://maps.googleapis.com/maps/api/js?v=3.exp' );
 
-		wp_register_script( 'google-maps-builder-gmaps', $google_maps_api_url, array( 'jquery' ) );
+		wp_register_script( 'google-maps-builder-gmaps', $google_maps_api_url, array( 'jquery' ), GMB_VERSION, true );
 
 	}
 
@@ -134,11 +135,12 @@ class Google_Maps_Builder_Scripts {
 	 * Print Gmap Footer
 	 */
 	function print_gmap_footer() {
+
 		if ( $this->load_maps_api ) {
-			wp_print_scripts( 'google-maps-builder-gmaps' );
+			wp_enqueue_script( 'google-maps-builder-gmaps' );
 		}
-		wp_print_scripts( 'google-maps-builder-plugin-script' );
-		wp_print_scripts( 'google-maps-builder-maps-icons' );
+		wp_enqueue_script( 'google-maps-builder-plugin-script' );
+		wp_enqueue_script( 'google-maps-builder-maps-icons' );
 	}
 
 	/**
@@ -155,6 +157,7 @@ class Google_Maps_Builder_Scripts {
 		if ( ! $wp_scripts ) {
 			return false;
 		}
+
 
 		//loop through registered scripts
 		foreach ( $wp_scripts->registered as $registered_script ) {
@@ -391,5 +394,3 @@ class Google_Maps_Builder_Scripts {
 	}
 
 }//end class
-
-


### PR DESCRIPTION
+ used wp_enqueue_scripts instead of the deprecated wp_print_scripts
+ used wp_enqueue_scripts action instead of wp_footer for hooking the function that load the gmaps api scripts
+ initialized the $in_footer parameter to true of the wp_register_script function to print the script in the footer.
I've tried with another plugin that load google maps api v3 and it seems to work properly, I mean it does load just one script. But maybe a more extensive testing should be performed since the ratio of the check_for_multiple_google_maps_api_calls function is slightly different from that I've imagined when I read it the first time. The problem with this function is that it check the presence of the same gmap script against the registered array so there can be a case when the script is registered but not printed and then the function sets load_maps_api variable to false anyway, causing no gmaps api script to be loaded (as was happening to my site).  I don't know if there is a way in WP to check if a script from another plugin is printed or not. I think that wp_script_is works only with handles and not with the script's src, so it is of no use for checking for same script loading.