### PR TITLE
Release/2.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/kevinwhoffman/maps-builder-core.git"
+      "url": "git@github.com:WordImpress/maps-builder-core.git"
     }
   ],
   "require": {
-    "wordimpress/maps-builder-core": "dev-release/2.1.2"
+    "wordimpress/maps-builder-core": "dev-master"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "git@github.com:WordImpress/maps-builder-core.git"
+      "url": "https://github.com/kevinwhoffman/maps-builder-core.git"
     }
   ],
   "require": {
-    "wordimpress/maps-builder-core": "dev-master"
+    "wordimpress/maps-builder-core": "dev-release/2.1.2"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4149e68b5c5d88867be013dcb01d04a7",
-    "content-hash": "187fd3a3371f55c7362c42da9efbb78e",
+    "hash": "c7bd29a2addac36a021435ef59286ada",
+    "content-hash": "9e21bbeed0e1f311081ff78ca47b89b2",
     "packages": [
         {
             "name": "wordimpress/maps-builder-core",
-            "version": "dev-master",
+            "version": "dev-release/2.1.2",
             "source": {
                 "type": "git",
-                "url": "git@github.com:WordImpress/maps-builder-core.git",
-                "reference": "11a7977828fc302a6c04431736a6e1fea029d21c"
+                "url": "https://github.com/kevinwhoffman/maps-builder-core.git",
+                "reference": "0a9ef1547abe950eeb28115aff43722eaaceb147"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordImpress/maps-builder-core/zipball/11a7977828fc302a6c04431736a6e1fea029d21c",
-                "reference": "11a7977828fc302a6c04431736a6e1fea029d21c",
+                "url": "https://api.github.com/repos/kevinwhoffman/maps-builder-core/zipball/0a9ef1547abe950eeb28115aff43722eaaceb147",
+                "reference": "0a9ef1547abe950eeb28115aff43722eaaceb147",
                 "shasum": ""
             },
             "type": "library",
@@ -33,10 +33,9 @@
             ],
             "description": "Shared code between Maps Builder Pro and free.",
             "support": {
-                "source": "https://github.com/WordImpress/maps-builder-core/tree/master",
-                "issues": "https://github.com/WordImpress/maps-builder-core/issues"
+                "source": "https://github.com/kevinwhoffman/maps-builder-core/tree/release/2.1.2"
             },
-            "time": "2016-07-07 23:40:12"
+            "time": "2017-07-03 03:48:12"
         }
     ],
     "packages-dev": [],

--- a/google-maps-builder.php
+++ b/google-maps-builder.php
@@ -120,6 +120,7 @@ if ( ! class_exists( 'Google_Maps_Builder' ) ) :
 					self::$instance->scripts  = new Google_Maps_Builder_Scripts();
 					self::$instance->settings = new Google_Maps_Builder_Settings();
 					self::$instance->engine   = new Google_Maps_Builder_Engine();
+					self::$instance->html     = new Google_Maps_Builder_HTML_Elements();
 
 					// Read plugin meta
 					// Check that function get_plugin_data exists
@@ -148,6 +149,7 @@ if ( ! class_exists( 'Google_Maps_Builder' ) ) :
 				$this->cmb2_load();
 				$this->load_files();
 				require_once GMB_PLUGIN_PATH . 'includes/class-gmb-scripts.php';
+				require_once GMB_PLUGIN_PATH . 'includes/class-gmb-html-elements.php';
 
 				if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 

--- a/google-maps-builder.php
+++ b/google-maps-builder.php
@@ -121,11 +121,6 @@ if ( ! class_exists( 'Google_Maps_Builder' ) ) :
 					self::$instance->settings = new Google_Maps_Builder_Settings();
 					self::$instance->engine   = new Google_Maps_Builder_Engine();
 
-					register_activation_hook( __FILE__, array(
-						self::$instance->activate,
-						'activation_flush_rewrites'
-					) );
-
 					// Read plugin meta
 					// Check that function get_plugin_data exists
 					if ( ! function_exists( 'get_plugin_data' ) ) {

--- a/includes/admin/class-gmb-shortcode-generator.php
+++ b/includes/admin/class-gmb-shortcode-generator.php
@@ -146,5 +146,3 @@ class GMB_Shortcode_Generator extends Google_Maps_Builder_Core_Shortcode_Generat
 	}
 
 }
-
-new GMB_Shortcode_Generator();

--- a/includes/class-gmb-engine.php
+++ b/includes/class-gmb-engine.php
@@ -101,6 +101,7 @@ class Google_Maps_Builder_Engine extends Google_Maps_Builder_Core_Engine {
 					'search_places' => ! empty( $all_meta['gmb_places_search_multicheckbox'][0] ) ? maybe_unserialize( $all_meta['gmb_places_search_multicheckbox'][0] ) : '',
 				),
 				'map_markers_icon' => ! empty( $all_meta['gmb_map_marker'] ) ? $all_meta['gmb_map_marker'][0] : 'none',
+				'current_post'        => get_the_ID(),
 			)
 		) );
 

--- a/includes/class-gmb-html-elements.php
+++ b/includes/class-gmb-html-elements.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * HTML elements
+ *
+ * A helper class for outputting common HTML elements, such as map drop downs
+ *
+ * @package     Google_Maps_Builder
+ * @subpackage  Classes/HTML
+ * @copyright   Copyright (c) 2015, WordImpress
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       2.1.2
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Google_Maps_Builder_HTML_Elements Class
+ *
+ * @since 2.1.2
+ */
+class Google_Maps_Builder_HTML_Elements extends Google_Maps_Builder_Core_HTML_Elements {
+
+}


### PR DESCRIPTION
This PR addresses issues in the [2.1.2 milestone](https://github.com/WordImpress/Google-Maps-Builder/milestone/7) related to Free functionality:

- Fixes duplicate/broken TinyMCE shortcode generator button https://github.com/WordImpress/Google-Maps-Builder/issues/234
- Improves developer access to map and marker data https://github.com/WordImpress/Google-Maps-Builder/issues/244
    - Adds current post ID to localized data (allows devs to manipulate map based on current post)